### PR TITLE
Config security

### DIFF
--- a/ContentService/src/main/java/com/example/contentservice/config/SecurityConfig.java
+++ b/ContentService/src/main/java/com/example/contentservice/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.example.contentservice.config;
 
 import com.example.commonmodule.security.AbstractSecurityConfig;
+import com.example.commonmodule.utils.Role;
+
 import java.util.Base64;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,12 +37,12 @@ public class SecurityConfig extends AbstractSecurityConfig {
   // TODO: 모듈별 권한 세부 설정
   @Override
   protected void configureAuthorization(HttpSecurity http) throws Exception {
-    String[] whiteList = {"/api/example", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"};
+    String[] whiteList = {"/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"};
     http.authorizeHttpRequests(auth -> auth
         .requestMatchers(whiteList).permitAll()
-        .requestMatchers("/api/admin/**").hasRole("ADMIN")
-        .requestMatchers(RegexRequestMatcher.regexMatcher("/orgs/.*/notices/.*"))
-        .hasRole("ORG_ADMIN").anyRequest().permitAll()
+        .requestMatchers(RegexRequestMatcher.regexMatcher("/orgs/.*/notices/.*")).hasRole(Role.ORG_ADMIN.getAuthority())
+        .requestMatchers("/ocr/upload/**").hasRole(Role.ORG_MANAGER.getAuthority())
+        .anyRequest().permitAll()
     );
     super.configureJwtResourceServer(http);
   }

--- a/ContentService/src/main/java/com/example/contentservice/fortune/controller/FortuneController.java
+++ b/ContentService/src/main/java/com/example/contentservice/fortune/controller/FortuneController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/v1/fortune")
+@RequestMapping("/fortune")
 @RequiredArgsConstructor
 public class FortuneController {
 

--- a/ContentService/src/main/java/com/example/contentservice/report/controller/HealthReportController.java
+++ b/ContentService/src/main/java/com/example/contentservice/report/controller/HealthReportController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/health-report")
+@RequestMapping("/health-report")
 @AllArgsConstructor
 @CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")
 public class HealthReportController {

--- a/GateWay/build.gradle
+++ b/GateWay/build.gradle
@@ -35,7 +35,7 @@ repositories {
 
 dependencies {
     implementation project(':CommonModule')
-    // implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/GateWay/src/main/java/com/example/gateway/security/GatewaySecurityConfig.java
+++ b/GateWay/src/main/java/com/example/gateway/security/GatewaySecurityConfig.java
@@ -17,7 +17,6 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
-import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;

--- a/GateWay/src/main/resources/application.yml
+++ b/GateWay/src/main/resources/application.yml
@@ -20,25 +20,24 @@ spring:
             - id: user-service
               uri: http://localhost:8081
               predicates:
-                - Path=/api/anonymous/user/**,/api/user/auth/**,
-                  /api/user/user/**,/api/org-manager/user/**,
-                  /api/org-admin/user/**,/api/org-manager/user/**, /api/org-manager/**, /api/organization/**
+                - Path=/api/anonymous/member/**,/api/user/member/**,
+                  /api/org-manager/member/**,/api/org-admin/member/**,/api/admin/member/**
               filters:
-                - StripPrefix=2
+                - StripPrefix=3
             - id: content-service
               uri: http://localhost:8082
               predicates:
-                - Path=/api/anonymous/notices/**,/api/user/notices/**,
-                  /api/org-manager/notices/**,/api/org-admin/notices/**,/api/admin/notices/**,
-                  /api/content/**, /api/content/calendar/**
+                - Path=/api/anonymous/content/**,/api/user/content/**,
+                  /api/org-manager/content/**,/api/org-admin/content/**,/api/admin/content/**
               filters:
-                - StripPrefix=2
+                - StripPrefix=3
             - id: chat-service
               uri: http://localhost:8083
               predicates:
-                - Path=/api/user/chat/**,/api/org-manager/chat/**,/api/org-admin/chat/**,/api/admin/chat/**
+                - Path=/api/user/chat/**,/api/org-manager/chat/**,
+                  /api/org-admin/chat/**,/api/admin/chat/**
               filters:
-                - StripPrefix=2
+                - StripPrefix=3
             
             # Swagger Routes
             - id: member-service-docs

--- a/MemberService/src/main/java/com/example/memberservice/controller/UserController.java
+++ b/MemberService/src/main/java/com/example/memberservice/controller/UserController.java
@@ -45,7 +45,7 @@ public class UserController {
 	 * @param dto 저장해야 하는 회원 정보
 	 * @return 성공시 계정이 생성되었다는 메시지
 	 */
-	@PostMapping("/auth/signup")
+	@PostMapping("/signup")
 	public ResponseEntity<MessageResponseDto> signUp(
 		@RequestPart(name = "profile")MultipartFile profile,
 		 @Valid @RequestPart(name = "data") SignUpRequestDto dto

--- a/MemberService/src/main/java/com/example/memberservice/controller/doc/LoginDocsController.java
+++ b/MemberService/src/main/java/com/example/memberservice/controller/doc/LoginDocsController.java
@@ -8,13 +8,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class LoginDocsController {
 
-  @PostMapping("/user/auth/login")
+  @PostMapping("/user/login")
   public void login(
       @RequestBody(description = "로그인 정보", required = true) LoginRequestDto loginRequestDto) {
     // 문서용이므로 실제 구현은 없음
   }
 
-  @PostMapping("/user/auth/logout")
+  @PostMapping("/user/logout")
   public void logout() {
     // 문서용이므로 실제 구현은 없음
   }

--- a/MemberService/src/main/java/com/example/memberservice/filter/CustomLoginFilter.java
+++ b/MemberService/src/main/java/com/example/memberservice/filter/CustomLoginFilter.java
@@ -32,7 +32,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
   public CustomLoginFilter(AuthenticationManager authenticationManager, JwtIssuer jwtIssuer) {
     this.authenticationManager = authenticationManager;
     this.jwtIssuer = jwtIssuer;
-    setFilterProcessesUrl("/user/auth/login");
+    setFilterProcessesUrl("/user/login");
   }
 
   // JSON Body 에서 자격증명 파싱

--- a/MemberService/src/main/java/com/example/memberservice/filter/CustomLogoutFilter.java
+++ b/MemberService/src/main/java/com/example/memberservice/filter/CustomLogoutFilter.java
@@ -41,7 +41,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
 
 		//path랑 메소드 확인
 		String requestUri=request.getRequestURI();
-		if(!requestUri.matches("/logout")){
+		if(!requestUri.matches("/user/logout")){
 			filterChain.doFilter(request, response);
 			return;
 		}

--- a/MemberService/src/main/java/com/example/memberservice/security/SecurityConfig.java
+++ b/MemberService/src/main/java/com/example/memberservice/security/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig extends AbstractSecurityConfig {
   @Override
   protected void configureAuthorization(HttpSecurity http) throws Exception {
     // TODO: 세부 권한, 화이트리스트 등록
-    String[] whiteList = {"/user/auth/signup", "/user/auth/login", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"};
+    String[] whiteList = {"/user/signup", "/user/login", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"};
     http.authorizeHttpRequests(auth -> auth
             .requestMatchers(whiteList).permitAll()
             .requestMatchers("/api/admin/**").hasRole("ADMIN")


### PR DESCRIPTION
- 게이트웨이 경로 수정(prefix=3, /api/{권한}/{모듈} 형식)
- 챗 모듈 제외, 각 security config의 화이트리스트 수정
- 몇몇 컨트롤러의 request mapping을 현재 게이트웨이 경로 형식에 맞게 변경